### PR TITLE
Added spacing under buttons in Ok/Cancel dialog.

### DIFF
--- a/nion/ui/Dialog.py
+++ b/nion/ui/Dialog.py
@@ -4,6 +4,7 @@
 
 # standard libraries
 import gettext
+import sys
 
 # typing
 from typing import Callable
@@ -63,7 +64,7 @@ class OkCancelDialog(Window.Window):
             button_row.add_spacing(13)
 
         content_column.add(button_row)
-        content_column.add_spacing(13)
+        if sys.platform == 'linux': content_column.add_spacing(13)
 
         self.attach_widget(content_column)
 
@@ -102,7 +103,7 @@ class ActionDialog(Window.Window):
         self.button_row.add_stretch()
 
         content_column.add(self.button_row)
-        content_column.add_spacing(13)
+        if sys.platform == 'linux': content_column.add_spacing(13)
 
         self.attach_widget(content_column)
 

--- a/nion/ui/Dialog.py
+++ b/nion/ui/Dialog.py
@@ -63,6 +63,7 @@ class OkCancelDialog(Window.Window):
             button_row.add_spacing(13)
 
         content_column.add(button_row)
+        content_column.add_spacing(13)
 
         self.attach_widget(content_column)
 

--- a/nion/ui/Dialog.py
+++ b/nion/ui/Dialog.py
@@ -102,6 +102,7 @@ class ActionDialog(Window.Window):
         self.button_row.add_stretch()
 
         content_column.add(self.button_row)
+        content_column.add_spacing(13)
 
         self.attach_widget(content_column)
 


### PR DESCRIPTION
This corrects the problem of the button clipping into the bottom of the window on Ubuntu.