### PR TITLE
Add missing files from source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE.txt
+recursive-include nion *.html *.qss


### PR DESCRIPTION
Files are missing from the source distribution (.tar.tz) on pypi. Add `MANIFEST.in` to include them.