### PR TITLE
Fix ui demo

### DIFF
--- a/nionui_app/nionui_examples/ui_demo/Groups.py
+++ b/nionui_app/nionui_examples/ui_demo/Groups.py
@@ -1,4 +1,5 @@
 from nion.utils import Model
+from nion.utils import Converter
 
 
 class Handler:
@@ -8,14 +9,18 @@ class Handler:
     def reset(self, widget):
         self.slider_value_model.value = 50
 
+    slider_converter = Converter.IntegerToStringConverter('{0}')
+
 
 def construct_ui(ui):
 
     slider = ui.create_slider(value="@binding(slider_value_model.value)")
 
-    progress_bar = ui.create_progress_bar(value="@binding(slider_value_model.value)")
+    progress_bar = ui.create_progress_bar(
+        value="@binding(slider_value_model.value)")
 
-    label = ui.create_label(text="@binding(slider_value_model.value)")
+    label = ui.create_label(
+        text="@binding(slider_value_model.value, converter=slider_converter)")
 
     button = ui.create_push_button(text="Reset to 50", on_clicked="reset")
 

--- a/nionui_app/nionui_examples/ui_demo/ProgressBars.py
+++ b/nionui_app/nionui_examples/ui_demo/ProgressBars.py
@@ -1,5 +1,5 @@
 from nion.utils import Model
-
+from nion.utils import Converter
 
 class Handler:
 
@@ -8,15 +8,16 @@ class Handler:
     def reset(self, widget):
         self.slider_value_model.value = 50
 
+    slider_converter = Converter.IntegerToStringConverter('{0}')
+
 
 def construct_ui(ui):
 
     slider = ui.create_slider(value="@binding(slider_value_model.value)")
-
-    progress_bar = ui.create_progress_bar(value="@binding(slider_value_model.value)")
-
-    label = ui.create_label(text="@binding(slider_value_model.value)")
-
+    progress_bar = ui.create_progress_bar(
+        value="@binding(slider_value_model.value)")
+    label = ui.create_label(
+        text="@binding(slider_value_model.value, converter=slider_converter)")
     button = ui.create_push_button(text="Reset to 50", on_clicked="reset")
-
+    
     return ui.create_column(progress_bar, slider, label, button, spacing=8)

--- a/nionui_app/nionui_examples/ui_demo/RadioButtons.py
+++ b/nionui_app/nionui_examples/ui_demo/RadioButtons.py
@@ -1,4 +1,5 @@
 from nion.utils import Model
+from nion.utils import Converter
 
 class Handler:
     radio_button_value = Model.PropertyModel(2)
@@ -7,11 +8,17 @@ class Handler:
     def reset_clicked(self, widget):
         self.radio_button_value.value = 2
 
+    radio_converter = Converter.IntegerToStringConverter('{0}')
+
 
 def construct_ui(ui):
-    radio0 = ui.create_radio_button(text="One", value=1, group_value="@binding(radio_button_value.value)")
-    radio1 = ui.create_radio_button(text="Two", value=2, group_value="@binding(radio_button_value.value)")
-    radio2 = ui.create_radio_button(text="Three", value=3, group_value="@binding(radio_button_value.value)")
-    label = ui.create_label(text="@binding(radio_button_value.value)")
+    radio0 = ui.create_radio_button(
+        text="One", value=1, group_value="@binding(radio_button_value.value)")
+    radio1 = ui.create_radio_button(
+        text="Two", value=2, group_value="@binding(radio_button_value.value)")
+    radio2 = ui.create_radio_button(
+        text="Three", value=3, group_value="@binding(radio_button_value.value)")
+    label = ui.create_label(
+        text="@binding(radio_button_value.value, converter=radio_converter)")
     button = ui.create_push_button(text="Reset", on_clicked="reset_clicked")
     return ui.create_column(radio0, radio1, radio2, label, button, spacing=8)

--- a/nionui_app/nionui_examples/ui_demo/Sliders.py
+++ b/nionui_app/nionui_examples/ui_demo/Sliders.py
@@ -1,5 +1,5 @@
 from nion.utils import Model
-
+from nion.utils import Converter
 
 class Handler:
 
@@ -17,6 +17,8 @@ class Handler:
 
     def slider_moved(self, widget, value):
         print(f"M {value}")
+    
+    slider_converter = Converter.IntegerToStringConverter(format="{0}")
 
 
 def construct_ui(ui):
@@ -25,7 +27,8 @@ def construct_ui(ui):
 
     slider2 = ui.create_slider(name="slider2", value="vv", on_value_changed="value_changed", on_slider_moved="slider_moved")
 
-    label = ui.create_label(text="@binding(slider_value_model.value)")
+    label = ui.create_label(
+        text="@binding(slider_value_model.value, converter=slider_converter)")
 
     button = ui.create_push_button(text="Reset to 50", on_clicked="reset")
 

--- a/nionui_app/nionui_examples/ui_demo/main.py
+++ b/nionui_app/nionui_examples/ui_demo/main.py
@@ -9,22 +9,23 @@ from nion.ui import Application
 from nion.ui import Declarative
 
 # ui imports
-from . import Bindings
-from . import Buttons
-from . import CheckBoxes
-from . import ComboBoxes
-from . import Compositions
-from . import ComponentLayout
-from . import ComponentStack
-from . import Converters
-from . import Groups
-from . import LineEdits
-from . import ProgressBars
-from . import RadioButtons
-from . import Sliders
-from . import Stacks
-from . import StatusBar
-from . import Tabs
+from nionui_app.nionui_examples.ui_demo import (
+    Bindings, 
+    Buttons, 
+    CheckBoxes, 
+    ComboBoxes, 
+    Compositions, 
+    ComponentLayout, 
+    ComponentStack,
+    Converters,
+    Groups,
+    LineEdits,
+    ProgressBars,
+    RadioButtons,
+    Sliders,
+    Stacks,
+    StatusBar,
+    Tabs, )
 
 _ = gettext.gettext
 

--- a/nionui_app/nionui_examples/ui_demo/main.py
+++ b/nionui_app/nionui_examples/ui_demo/main.py
@@ -9,7 +9,7 @@ from nion.ui import Application
 from nion.ui import Declarative
 
 # ui imports
-from nionui_app.nionui_examples.ui_demo import (
+from . import (
     Bindings, 
     Buttons, 
     CheckBoxes, 


### PR DESCRIPTION
Dear Nion devs, 

I have been using the thorough examples in `nionui_app.nionui_examples.ui_demo` which are great to learn about NionUI. I've found some of the widget displays returned Errors. The issues was always that these widgets were trying to display variables that were not properly converted to string type. I have fixed the issues that I've found identifying these variables and attaching the corresponding `nion.utils.Converter` object.

Best regards,
Alberto.

# Description of the changes
- Fixed the following widgets: Slider, Radio Buttons, Progress Bar, and Groups.
- Some code cleaning
