### PR TITLE
Fix #681 Add 'TestFontMetrics' class to approximate real font width calculations

### DIFF
--- a/nion/ui/TestUI.py
+++ b/nion/ui/TestUI.py
@@ -21,13 +21,13 @@ focused_widget = None  # simulate focus handling at the widget level
 
 class TestFontMetrics:
     def __init__(self,
-                 display_scaling: float,
-                 font_metrics_height: float,
-                 font_metrics_ascent: float,
-                 font_metrics_descent: float,
-                 font_metrics_leading: float,
-                 font_width_and_chars: typing.Iterable[typing.Tuple[float, str]],
-                 default_char_width: float):
+                 display_scaling: int,
+                 font_metrics_height: int,
+                 font_metrics_ascent: int,
+                 font_metrics_descent: int,
+                 font_metrics_leading: int,
+                 font_width_and_chars: typing.Iterable[typing.Tuple[int, str]],
+                 default_char_width: int):
         """
         :param font_width_and_chars: iterator over `(width, chars)` where `chars` is the string consisting
             of characters whose width is `width` for the font.
@@ -59,7 +59,7 @@ class TestFontMetrics:
                                                leading=self._font_metrics_leading / self._display_scaling)
 
 
-def calculate_font_metric_info_for_tests(font_str: str, display_scaling: str) -> str:
+def calculate_font_metric_info_for_tests(font_str: str, display_scaling: float) -> str:
     """
     For now, this is hardcoded to use Qt for the font metrics
 
@@ -73,34 +73,32 @@ def calculate_font_metric_info_for_tests(font_str: str, display_scaling: str) ->
     """
     # Use local imports so Qt is not required for module to load
     from nion.ui.PyQtProxy import ParseFontString, QtGui
-    display_scaling = 1.0
-    font_str = "normal 11px serif"
     font = ParseFontString(font_str, display_scaling)
 
     font_metrics = QtGui.QFontMetrics(font)
 
-    font_chars_by_width = collections.defaultdict(list)
+    font_metrics_height = font_metrics.height()
+    font_metrics_ascent = font_metrics.ascent()
+    font_metrics_descent = font_metrics.descent()
+    font_metrics_leading = font_metrics.leading()
 
-    font_metrics_height = float(font_metrics.height())
-    font_metrics_ascent = float(font_metrics.ascent())
-    font_metrics_descent = float(font_metrics.descent())
-    font_metrics_leading = float(font_metrics.leading())
+    default_char_width = font_metrics.width('M')
 
-    default_char_width = float(font_metrics.width('M'))
+    font_chars_arr_by_width = collections.defaultdict(list)
 
     for char_ord in range(ord(' '), ord('~')+ 1):
         char = chr(char_ord)
-        width = float(font_metrics.width(char))
-        font_chars_by_width[width].append(char)
+        width = font_metrics.width(char)
+        font_chars_arr_by_width[width].append(char)
 
     # Sort by numbers of characters at a given width, descending
-    font_chars_by_width = dict(
-        (k, ''.join(v)) for k, v in sorted(font_chars_by_width.items(),
+    font_chars_str_by_width = dict(
+        (k, ''.join(v)) for k, v in sorted(font_chars_arr_by_width.items(),
                                            key=lambda _: (-len(_[1]), _[0])))
 
     font_chars_by_width_dict_entries = "\n".join(
         "            {}: {},".format(width, json.dumps(chars))
-        for width, chars in font_chars_by_width.items()
+        for width, chars in font_chars_str_by_width.items()
     )
 
     test_font_metrics_str = f"""
@@ -129,22 +127,22 @@ def make_font_metrics_for_tests():
     """
     return TestFontMetrics(
         display_scaling=1.0,
-        font_metrics_height=13.0,
-        font_metrics_ascent=11.0,
-        font_metrics_descent=2.0,
-        font_metrics_leading=0.0,
+        font_metrics_height=13,
+        font_metrics_ascent=11,
+        font_metrics_descent=2,
+        font_metrics_leading=0,
         font_width_and_chars={
-            7.0: "#$+02345689<=>ABEKPRSTVYZ^bdghopq~",
-            6.0: "7?FJL_`aceknsuvxyz",
-            3.0: " !',./:;I\\ijl|",
-            4.0: "()[]frt{}",
-            8.0: "&CDGHNUX",
-            5.0: "\"*-1",
-            10.0: "%@Mm",
-            9.0: "OQw",
-            11.0: "W",
+            7: "#$+02345689<=>ABEKPRSTVYZ^bdghopq~",
+            6: "7?FJL_`aceknsuvxyz",
+            3: " !',./:;I\\ijl|",
+            4: "()[]frt{}",
+            8: "&CDGHNUX",
+            5: "\"*-1",
+            10: "%@Mm",
+            9: "OQw",
+            11: "W",
         },
-        default_char_width=10.0
+        default_char_width=10
     )
 
 

--- a/nion/ui/TestUI.py
+++ b/nion/ui/TestUI.py
@@ -35,7 +35,7 @@ class TestFontMetrics:
         """
         font_chars_by_width = dict(font_width_and_chars)
 
-        font_width_by_char = dict()
+        font_width_by_char: typing.Dict[str, int] = dict()
         for width, chars in font_chars_by_width.items():
             font_width_by_char.update((char, width) for char in chars)
 

--- a/nion/ui/test/TestUI_test.py
+++ b/nion/ui/test/TestUI_test.py
@@ -1,0 +1,28 @@
+# standard libraries
+import unittest
+
+# third party libraries
+# None
+
+# local libraries
+from nion.ui import TestUI
+from nion.ui import UserInterface as UserInterfaceModule
+
+
+class TestTestUIUserInterface(unittest.TestCase):
+
+    def setUp(self):
+        self.ui = TestUI.UserInterface()
+
+    def tearDown(self):
+        pass
+
+    def test_get_font_metrics_sanity_check(self):
+        # Test that TestUI.UserInterface.get_font_metrics returns a reasonable size
+        # This test will need to be updated if 'make_font_metrics_for_tests' is modified
+        self.assertEqual(self.ui.get_font_metrics("ignored", "This is a string"),
+                         UserInterfaceModule.FontMetrics(77, 13, 11, 2, 0))
+
+    def test_default_font_metrics_is_var_width(self):
+        self.assertNotEqual(self.ui.get_font_metrics("ignored", "111"),
+                            self.ui.get_font_metrics("ignored", "999"))


### PR DESCRIPTION
* Add class `TestFontMetrics` that implements a `get_font_metrics` method that has configurable widths that can vary by character
* Add function `calculate_font_metric_info_for_tests` that can produce a python code snippet that constructs a `TestFontMetrics` instance for a specified font, using the Qt library
* Add function `make_font_metrics_for_tests` that constructs a `TestFontMetrics` instance for use by automated tests, using the code snippet returned by `calculate_font_metric_info_for_tests` called from a script console for font `"normal 11px serif"`
* Modify `TestUI.UserInterface.get_font_metrics` to calculate font metrics using the `TestFontMetrics` returned by `make_font_metrics_for_tests`