### PR TITLE
Fix Issue 143 - Comboboxes scrolling when not expanded

### DIFF
--- a/nion/ui/CanvasItem.py
+++ b/nion/ui/CanvasItem.py
@@ -4760,6 +4760,7 @@ class TimestampCanvasItem(AbstractCanvasItem):
     def __init__(self) -> None:
         super().__init__()
         self.__timestamp: typing.Optional[datetime.datetime] = None
+        self.__used_timestamp: typing.Optional[datetime.datetime] = None
 
     @property
     def timestamp(self) -> typing.Optional[datetime.datetime]:
@@ -4768,11 +4769,15 @@ class TimestampCanvasItem(AbstractCanvasItem):
     @timestamp.setter
     def timestamp(self, value: typing.Optional[datetime.datetime]) -> None:
         self.__timestamp = value
-        # self.update()
+        self.__used_timestamp = value
 
     def _repaint_if_needed(self, drawing_context: DrawingContext.DrawingContext, *, immediate: bool = False) -> None:
-        if self.__timestamp:
-            drawing_context.timestamp(self.__timestamp.isoformat())
+        if self.__used_timestamp:
+            drawing_context.timestamp(self.__used_timestamp.isoformat())
+            self.__used_timestamp = None
+        elif self.__timestamp:
+            # tell host to use last timestamp it knows about.
+            drawing_context.timestamp("last")
         super()._repaint_if_needed(drawing_context)
 
 

--- a/nion/ui/PyQtProxy.py
+++ b/nion/ui/PyQtProxy.py
@@ -507,11 +507,16 @@ class PyComboBox(QtWidgets.QComboBox):
 
     # override the scroll wheel handler in QComboBox
     def wheelEvent(self, event: QtCore.QWheelEvent):
-        # If we are not expanded, ignore the scroll wheel event
-        if not self.view().isVisible():
-            event.ignore()
-        else:
+        if self.isExpanded():
             super().wheelEvent(event)
+        else:
+            event.ignore()
+
+    def isExpanded(self) -> bool:
+        view = self.view()
+        if view is None:
+            return False  # It can't be expanded if it doesn't exist
+        return view.isVisible()
 
 
 class PySlider(QtWidgets.QSlider):

--- a/nion/ui/PyQtProxy.py
+++ b/nion/ui/PyQtProxy.py
@@ -505,6 +505,14 @@ class PyComboBox(QtWidgets.QComboBox):
                 import traceback
                 traceback.print_exc()
 
+    # override the scroll wheel handler in QComboBox
+    def wheelEvent(self, event: QtCore.QWheelEvent):
+        # If we are not expanded, ignore the scroll wheel event
+        if not self.view().isVisible():
+            event.ignore()
+        else:
+            super().wheelEvent(event)
+
 
 class PySlider(QtWidgets.QSlider):
 


### PR DESCRIPTION
Added an overridden handler for the scrollwheel to remove the situation where the scrollwheel was attemping to scroll comboboxes when they were not expanded.