### PR TITLE
Iss983 - Set handled flag on mouse released

### DIFF
--- a/nion/ui/PyQtProxy.py
+++ b/nion/ui/PyQtProxy.py
@@ -2112,7 +2112,9 @@ class PyCanvas(QtWidgets.QWidget):
         if self.object and event.button() == QtCore.Qt.LeftButton:
             display_scaling = GetDisplayScaling()
             try:
-                self.object.mouseReleased(event.position().x() // display_scaling, event.position().y() // display_scaling, event.modifiers().value)
+                result = self.object.mouseReleased(event.position().x() // display_scaling, event.position().y() // display_scaling, event.modifiers().value)
+                if result:
+                    event.accept()
             except Exception as e:
                 import traceback
                 traceback.print_exc()

--- a/nion/ui/QtUserInterface.py
+++ b/nion/ui/QtUserInterface.py
@@ -1659,10 +1659,10 @@ class QtCanvasWidgetBehavior(QtWidgetBehavior):
         if callable(self.on_mouse_pressed):
             self.on_mouse_pressed(x, y, QtKeyboardModifiers(raw_modifiers))
 
-    def mouseReleased(self, x: int, y: int, raw_modifiers: int) -> None:
+    def mouseReleased(self, x: int, y: int, raw_modifiers: int) -> bool:
         self._register_ui_activity()
         if callable(self.on_mouse_released):
-            self.on_mouse_released(x, y, QtKeyboardModifiers(raw_modifiers))
+            return  self.on_mouse_released(x, y, QtKeyboardModifiers(raw_modifiers))
 
     def mousePositionChanged(self, x: int, y: int, raw_modifiers: int) -> None:
         if callable(self.on_mouse_position_changed):

--- a/nion/ui/QtUserInterface.py
+++ b/nion/ui/QtUserInterface.py
@@ -1662,7 +1662,8 @@ class QtCanvasWidgetBehavior(QtWidgetBehavior):
     def mouseReleased(self, x: int, y: int, raw_modifiers: int) -> bool:
         self._register_ui_activity()
         if callable(self.on_mouse_released):
-            return  self.on_mouse_released(x, y, QtKeyboardModifiers(raw_modifiers))
+            return self.on_mouse_released(x, y, QtKeyboardModifiers(raw_modifiers))
+        return False
 
     def mousePositionChanged(self, x: int, y: int, raw_modifiers: int) -> None:
         if callable(self.on_mouse_position_changed):


### PR DESCRIPTION
When a mouse-released event is handled,  set the accepted flag on the event so it doesn't propagate up to the parent control and trigger a selection event.