### PR TITLE
Fix layout issue when making canvas item composer invisible.

### DIFF
--- a/nion/ui/CanvasItem.py
+++ b/nion/ui/CanvasItem.py
@@ -1126,6 +1126,13 @@ class AbstractCanvasItem:
         if self.__visible != value:
             self.__visible = value
             self.update()
+            # the regular update path will only invalidate the composer and call _updated
+            # if the item is visible. if we just set it to not visible, we need to call it
+            # here to get things to update properly. hack. one place where this would show
+            # up is in the line plot legend being set between none and top-right.
+            if not self.__visible:
+                self._invalidate_composer()
+                self._updated()
 
     @property
     def is_visible(self) -> bool:

--- a/nion/ui/test/CanvasItem_test.py
+++ b/nion/ui/test/CanvasItem_test.py
@@ -1710,7 +1710,7 @@ class TestCanvasItemClass(unittest.TestCase):
         outer_layer = CanvasItem.LayerCanvasItem()
         with contextlib.closing(outer_layer):
             test_canvas_item = TestCanvasItem()
-            test_canvas_item.repaint_delay = 0.05
+            test_canvas_item.repaint_delay = 0.1
             outer_layer.add_canvas_item(test_canvas_item)
             # update the outer layer with the initial size
             outer_layer.update_layout(Geometry.IntPoint(), Geometry.IntSize(width=640, height=480))


### PR DESCRIPTION
This showed up on line plot legend when set to be invisible.