### PR TITLE
fix non contiguous bitmaps

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ UNRELEASED
 ----------
 - Add support for align and truncation to TextCanvasItem.
 - Add a focus_changed_event to canvas item.
+- Ensure bitmaps passed to host drawing system are in the correct format (c-contiguous).
 
 9.0.1 (2025-02-11)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,9 +3,14 @@ Changelog (nionui)
 
 UNRELEASED
 ----------
-- Add support for align and truncation to TextCanvasItem.
-- Add a focus_changed_event to canvas item.
 - Ensure bitmaps passed to host drawing system are in the correct format (c-contiguous).
+- Improve sizing algorithm for minimal push button style to handle min/max better.
+- Improve drag and drop handling to not show drop indicator when not needed.
+- Improve action handling for improved customization.
+- Add a focus_changed_event to canvas item.
+- Add support for align and truncation to TextCanvasItem.
+- Add grid flow canvas item to allow for more complex layouts such as grid views.
+- Add stack canvas item.
 
 9.0.1 (2025-02-11)
 ------------------

--- a/nion/ui/DrawingContext.py
+++ b/nion/ui/DrawingContext.py
@@ -603,6 +603,9 @@ class DrawingContext:
         self.binary_commands.extend(struct.pack("4sffff", b"quad", float(x1), float(y1), float(x), float(y)))
 
     def draw_image(self, img: RGBA32Type, x: float, y: float, width: float, height: float) -> None:
+        # The host application expects the image to be contiguous c-style memory. Check and update here if required.
+        if not img.flags['C_CONTIGUOUS']:
+            img = numpy.ascontiguousarray(img)
         # img should be rgba pack, uint32
         assert img.dtype == numpy.uint32
         # The numpy-2 compatible nionui-tool takes an object which has the bytearray interface. The hdf5 dataset does
@@ -617,6 +620,11 @@ class DrawingContext:
         self.binary_commands.extend(struct.pack("4siiiffff", b"imag", img.shape[1], img.shape[0], int(image_id), float(x), float(y), float(width), float(height)))
 
     def draw_data(self, img: GrayscaleF32Type, x: float, y: float, width: float, height: float, low: float, high: float, color_map_data: typing.Optional[RGBA32Type]) -> None:
+        # The host application expects the image to be contiguous c-style memory. Check and update here if required.
+        if not img.flags['C_CONTIGUOUS']:
+            img = numpy.ascontiguousarray(img)
+        if color_map_data is not None and color_map_data.flags['C_CONTIGUOUS']:
+            color_map_data = numpy.ascontiguousarray(color_map_data)
         # img should be float
         assert img.dtype == numpy.float32
         # The numpy-2 compatible nionui-tool takes an object which has the bytearray interface. The hdf5 dataset does


### PR DESCRIPTION
- **Ensure bitmaps passed to host for drawing are c-contiguous.**
- **Update change log.**

This is a direct fix, so I merged this. Please review for education purposes. On the off chance you see and issue, I can do a follow-up, too.