### PR TITLE
Fix key pressed logic to handle focus changing while key is down.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changelog (nionui)
 ==================
 
+10.1.1 (UNRELEASED)
+-------------------
+- Fix key pressed logic to handle focus changing while key is down.
+
 10.1.0 (2025-05-27)
 -------------------
 - Add ability to handle double clicks in list items.


### PR DESCRIPTION
The problem can occur if a key is pressed and focus is changed by
either the mouse or another window appearing. Now the key released
message is sent when focus is changed.
