### PR TITLE
Remove self reference in request_close closure leading to zombie object

### DIFF
--- a/nion/ui/Dialog.py
+++ b/nion/ui/Dialog.py
@@ -192,13 +192,16 @@ class PopupWindow(Window.Window):
 
         from nion.ui import Declarative  # avoid circular reference
 
+        weakself = weakref.ref(self)
         def request_close() -> None:
             # this may be called in response to the user clicking a button to close.
             # make sure that the button is not destructed as a side effect of closing
             # the window by queueing the close. and it is not possible to use event loop
             # here because the event loop limitations: not able to run both parent and child
             # event loops simultaneously.
-            parent_window.queue_task(self.request_close)
+            obj = weakself()
+            if obj:
+                parent_window.queue_task(obj.request_close)
 
         # make and attach closer for the handler; put handler into container closer
         self.__closer = Declarative.Closer()

--- a/nion/ui/Dialog.py
+++ b/nion/ui/Dialog.py
@@ -190,7 +190,6 @@ class PopupWindow(Window.Window):
         super().__init__(parent_window.ui, app=parent_window.app, parent_window=parent_window, window_style=window_style)
 
         self.__delegate = weakref.ref(delegate) if delegate else None
-        self.__parent_window = parent_window
 
         from nion.ui import Declarative  # avoid circular reference
 
@@ -223,7 +222,7 @@ class PopupWindow(Window.Window):
         # the window by queueing the close. and it is not possible to use event loop
         # here because the event loop limitations: not able to run both parent and child
         # event loops simultaneously.
-        self.__parent_window.queue_task(self.request_close)
+        self.parent_window.queue_task(self.request_close)
 
     def show(self, *, size: typing.Optional[Geometry.IntSize] = None, position: typing.Optional[Geometry.IntPoint] = None) -> None:
         if position is None:


### PR DESCRIPTION
The request_close function contained a closure reference to self meaning that the PopupWindow object remained even after closing. Discovered while looking at the DisplayEditPopup in Swift.