### PR TITLE
Add more arguments for edit string popups

### DIFF
--- a/nion/ui/Dialog.py
+++ b/nion/ui/Dialog.py
@@ -448,3 +448,12 @@ def pose_confirmation_pop_up(completion_fn: typing.Callable[[bool], None], *,
 
     popup.on_close = functools.partial(handle_close, popup.on_close)
     popup.show(size=size, position=position)
+
+
+def get_popup_position(parent_panel_rect: Geometry.IntRect, popup_size: Geometry.IntSize) -> Geometry.IntPoint:
+    """Calculate the position for a popup panel from the parent container, and its size.
+
+    It is vertically aligned to be hanging from the top third of the parent panel.
+    """
+    vertical_position = parent_panel_rect.top + parent_panel_rect.height // 2 // 3
+    return Geometry.IntPoint(x=parent_panel_rect.left + (parent_panel_rect.width - popup_size.width) // 2, y=vertical_position + popup_size.height)

--- a/nion/ui/Dialog.py
+++ b/nion/ui/Dialog.py
@@ -323,6 +323,7 @@ def pose_select_item_pop_up(items: typing.Sequence[typing.Any], completion_fn: t
 def pose_edit_string_pop_up(current_string: str, completion_fn: typing.Callable[[str | None], None], *,
                             window: Window.Window, title: typing.Optional[str] = None,
                             position: Geometry.IntPoint | None = None, size: Geometry.IntSize | None = None,
+                            cancel_button_text: str | None = None, accept_button_text: str | None = None,
                             parent_rect: Geometry.IntRect | None = None, position_offset: Geometry.IntSize | Geometry.FloatSize | None = None) -> None:
     """ Create a popup with a text input field.
 
@@ -356,16 +357,14 @@ def pose_edit_string_pop_up(current_string: str, completion_fn: typing.Callable[
 
         def reject(self, widget: UserInterface.Widget) -> bool:
             # receive this when the user hits escape. let the window handle the escape by returning False.
-            # mark popup as rejected.
-            self.__request_close_fn()
             return False
 
         def accept(self, widget: UserInterface.Widget) -> bool:
             # receive this when the user hits return. need to request a close and return True to say we handled event.
             if self.line_edit_widget:
                 self.s = self.line_edit_widget.text or str()
-            self.__request_close_fn()
             self.is_rejected = False
+            self.__request_close_fn()
             return True
 
         def handle_cancel(self, widget: UserInterface.Widget) -> None:
@@ -374,18 +373,22 @@ def pose_edit_string_pop_up(current_string: str, completion_fn: typing.Callable[
     from nion.ui import Declarative  # avoid circular reference
     size, position = _get_pop_up_size_and_position(window, position=position, size=size, parent_rect=parent_rect, position_offset=position_offset)
     # calculate the max string width, add 10%, min 200, max 480
-    size = size or Geometry.IntSize(30, 200)
     width = (size.width - 20) if size else min(max(int(window.get_font_metrics("system", current_string).width * 1.10), 200), 480)
 
     ui_handler = Handler(current_string)
     u = Declarative.DeclarativeUI()
-    title_row = u.create_row(u.create_label(text=title or _("Edit")), u.create_stretch())
-    edit_row = u.create_row(u.create_line_edit(name="line_edit_widget", text="@binding(s)", width=width, on_return_pressed="accept", on_escape_pressed="reject", on_editing_finished="editing_finished"), u.create_stretch())
-    column = u.create_column(title_row, edit_row, spacing=4, margin=8)
-    # passing window_style=None is essential for making copy and paste work, as the 'popup' style does not handle copy/paste.
-    popup = PopupWindow(window, column, ui_handler, window_style=None, delegate=ui_handler)
-    # but we still want a clean window style
-    popup._document_window.set_window_style(["tool", "frameless-hint"])
+    title_row = u.create_row(u.create_label(text=title or _("Edit")), margin_left=8, margin_right=8, margin_top=4, margin_bottom=4, background_color="#DDD")
+    edit_row = u.create_row(u.create_line_edit(name="line_edit_widget", text="@binding(s)", on_return_pressed="accept", on_escape_pressed="reject", width=width), u.create_stretch(), spacing=4, margin=8)
+    column = u.create_column(title_row, edit_row, u.create_stretch())
+    if cancel_button_text is not None or accept_button_text is not None:
+        cancel_button_text = cancel_button_text or _("Cancel")
+        accept_button_text = accept_button_text or _("Done")
+        button_row = u.create_row(u.create_stretch(),
+                                  u.create_push_button(text=cancel_button_text, on_clicked="handle_cancel"),
+                                  u.create_push_button(text=accept_button_text, on_clicked="accept"), spacing=8, margin=8)
+        column = u.create_column(column, button_row)
+    # Passing window_style='popup' previously did not handle copy/paste, this issue seems to be resolved.
+    popup = PopupWindow(window, column, ui_handler, window_style='popup', delegate=ui_handler)
 
     def handle_close(old_close: typing.Callable[[], None] | None) -> None:
         if not ui_handler.is_rejected:

--- a/nion/ui/Dialog.py
+++ b/nion/ui/Dialog.py
@@ -310,7 +310,8 @@ def pose_select_item_pop_up(items: typing.Sequence[typing.Any], completion_fn: t
 
 def pose_edit_string_pop_up(current_string: str, completion_fn: typing.Callable[[str | None], None], *,
                             window: Window.Window, title: typing.Optional[str] = None,
-                            position: Geometry.IntPoint | None = None, size: Geometry.IntSize | None = None) -> None:
+                            position: Geometry.IntPoint | None = None, size: Geometry.IntSize | None = None, window_style: str | None = None,
+                            cancel_button_text: str | None = None, accept_button_text: str | None = None) -> None:
 
     class Handler:
         def __init__(self, s: str) -> None:
@@ -360,8 +361,15 @@ def pose_edit_string_pop_up(current_string: str, completion_fn: typing.Callable[
     title_row = u.create_row(u.create_label(text=title or _("Edit")), u.create_stretch())
     edit_row = u.create_row(u.create_line_edit(name="line_edit_widget", text="@binding(s)", width=width, on_return_pressed="accept", on_escape_pressed="reject", on_editing_finished="editing_finished"), u.create_stretch())
     column = u.create_column(title_row, edit_row, spacing=4, margin=8)
-    # passing window_style=None is essential for making copy and paste work, as the 'popup' style does not handle copy/paste.
-    popup = PopupWindow(window, column, ui_handler, window_style=None, delegate=ui_handler)
+    if cancel_button_text is not None or accept_button_text is not None:
+        cancel_button_text = cancel_button_text or _("Cancel")
+        accept_button_text = accept_button_text or _("Done")
+        button_row = u.create_row(u.create_stretch(),
+                                  u.create_push_button(text=cancel_button_text, on_clicked="handle_cancel"),
+                                  u.create_push_button(text=accept_button_text, on_clicked="editing_finished"), spacing=8, margin=8)
+        column = u.create_column(u.create_column(column, u.create_stretch()), button_row)
+    # passing window_style='popup' previously did not handle copy/paste, this issue seems to be resolved.
+    popup = PopupWindow(window, column, ui_handler, window_style=window_style, delegate=ui_handler)
     # but we still want a clean window style
     popup._document_window.set_window_style(["tool", "frameless-hint"])
 

--- a/nion/ui/Dialog.py
+++ b/nion/ui/Dialog.py
@@ -318,6 +318,7 @@ def pose_edit_string_pop_up(current_string: str, completion_fn: typing.Callable[
             self.is_rejected = True
             self.s = s
             self.line_edit_widget: UserInterface.LineEditWidget | None = None
+            self.call_close_on_reject = window_style != "default"
 
         def close(self) -> None:
             pass
@@ -335,6 +336,8 @@ def pose_edit_string_pop_up(current_string: str, completion_fn: typing.Callable[
 
         def reject(self, widget: UserInterface.Widget) -> bool:
             # receive this when the user hits escape. let the window handle the escape by returning False.
+            if self.call_close_on_reject:
+                self.__request_close_fn()
             return False
 
         def accept(self, widget: UserInterface.Widget) -> bool:

--- a/nion/ui/Dialog.py
+++ b/nion/ui/Dialog.py
@@ -335,8 +335,6 @@ def pose_edit_string_pop_up(current_string: str, completion_fn: typing.Callable[
 
         def reject(self, widget: UserInterface.Widget) -> bool:
             # receive this when the user hits escape. let the window handle the escape by returning False.
-            # mark popup as rejected.
-            self.__request_close_fn()
             return False
 
         def accept(self, widget: UserInterface.Widget) -> bool:
@@ -358,20 +356,20 @@ def pose_edit_string_pop_up(current_string: str, completion_fn: typing.Callable[
 
     ui_handler = Handler(current_string)
     u = Declarative.DeclarativeUI()
-    title_row = u.create_row(u.create_label(text=title or _("Edit")), u.create_stretch())
-    edit_row = u.create_row(u.create_line_edit(name="line_edit_widget", text="@binding(s)", width=width, on_return_pressed="accept", on_escape_pressed="reject", on_editing_finished="editing_finished"), u.create_stretch())
-    column = u.create_column(title_row, edit_row, spacing=4, margin=8)
+    title_row = u.create_row(u.create_label(text=title or _("Edit")), margin_left=8, margin_right=8, margin_top=4, margin_bottom=4, background_color="#DDD")
+    divider = u.create_row(u.create_stretch(), background_color="#AAA", height=1)
+    title_row = u.create_column(title_row, divider)
+    edit_row = u.create_row(u.create_line_edit(name="line_edit_widget", text="@binding(s)", on_return_pressed="accept", on_escape_pressed="reject", width=width), u.create_stretch(), spacing=4, margin=8)
+    column = u.create_column(title_row, edit_row)
     if cancel_button_text is not None or accept_button_text is not None:
         cancel_button_text = cancel_button_text or _("Cancel")
         accept_button_text = accept_button_text or _("Done")
         button_row = u.create_row(u.create_stretch(),
                                   u.create_push_button(text=cancel_button_text, on_clicked="handle_cancel"),
-                                  u.create_push_button(text=accept_button_text, on_clicked="editing_finished"), spacing=8, margin=8)
+                                  u.create_push_button(text=accept_button_text, on_clicked="accept"), spacing=8, margin=8)
         column = u.create_column(u.create_column(column, u.create_stretch()), button_row)
     # passing window_style='popup' previously did not handle copy/paste, this issue seems to be resolved.
     popup = PopupWindow(window, column, ui_handler, window_style=window_style, delegate=ui_handler)
-    # but we still want a clean window style
-    popup._document_window.set_window_style(["tool", "frameless-hint"])
 
     def handle_close(old_close: typing.Callable[[], None] | None) -> None:
         if not ui_handler.is_rejected:
@@ -388,3 +386,65 @@ def pose_edit_string_pop_up(current_string: str, completion_fn: typing.Callable[
     assert line_edit_widget
     line_edit_widget.focused = False
     line_edit_widget.focused = True
+
+
+def pose_confirmation_pop_up(completion_fn: typing.Callable[[bool], None], *,
+                             window: Window.Window, title: str | None = None, caption: str | None = None,
+                             position: Geometry.IntPoint | None = None, size: Geometry.IntSize | None = None, window_style: str | None = None,
+                             cancel_button_text: str = _("Cancel"), accept_button_text: str = _("Done")) -> None:
+    """Display a confirmation popup"""
+    class Handler:
+        def __init__(self) -> None:
+            self.is_rejected = True
+
+        def close(self) -> None:
+            pass
+
+        def init_popup(self, request_close_fn: typing.Callable[[], None]) -> None:
+            self.__request_close_fn = request_close_fn
+
+        def reject(self, widget: UserInterface.Widget) -> bool:
+            # receive this when the user hits escape. let the window handle the escape by returning False.
+            # mark popup as rejected.
+            self.__request_close_fn()
+            return False
+
+        def accept(self, widget: UserInterface.Widget) -> bool:
+            # receive this when the user hits return. need to request a close and return True to say we handled event.
+            self.__request_close_fn()
+            self.is_rejected = False
+            return True
+
+    from nion.ui import Declarative  # avoid circular reference
+
+    # calculate the max string width, add 10%, min 200, max 480
+    size = size or Geometry.IntSize(30, 200)
+
+    ui_handler = Handler()
+    u = Declarative.DeclarativeUI()
+
+    title_row = u.create_row(u.create_label(text=title or _("Confirm")), margin_left=8, margin_right=8, margin_top=4, margin_bottom=4, background_color="#DDD")
+    divider = u.create_row(u.create_stretch(), background_color="#AAA", height=1)
+    title_row = u.create_column(title_row, divider)
+    button_row = u.create_row(u.create_stretch(),
+                              u.create_push_button(text=cancel_button_text, on_clicked="reject"),
+                              u.create_push_button(text=accept_button_text, on_clicked="accept"), spacing=8, margin=8)
+
+    if caption:
+        caption_row = u.create_row(u.create_label(text=caption), u.create_stretch(), spacing=4, margin=8)
+        column = u.create_column(title_row, caption_row, button_row)
+    else:
+        column = u.create_column(title_row, button_row)
+
+    popup = PopupWindow(window, column, ui_handler, window_style=window_style, delegate=ui_handler)
+
+    def handle_close(old_close: typing.Callable[[], None] | None) -> None:
+        if not ui_handler.is_rejected:
+            completion_fn(True)
+        else:
+            completion_fn(False)
+        if callable(old_close):
+            old_close()
+
+    popup.on_close = functools.partial(handle_close, popup.on_close)
+    popup.show(size=size, position=position)

--- a/nion/ui/Dialog.py
+++ b/nion/ui/Dialog.py
@@ -244,8 +244,18 @@ class PopupWindow(Window.Window):
 def pose_select_item_pop_up(items: typing.Sequence[typing.Any], completion_fn: typing.Callable[[typing.Any], None], *,
                             window: Window.Window, current_item: int = 0,
                             item_getter: typing.Optional[typing.Callable[[typing.Any], str]] = None,
-                            title: typing.Optional[str] = None) -> None:
+                            title: typing.Optional[str] = None, position: Geometry.IntPoint | None = None,
+                            size: Geometry.IntSize | None = None, parent_rect: Geometry.IntRect | None = None,
+                            position_offset: Geometry.IntSize | Geometry.FloatSize | None = None) -> None:
+    """Create a popup that allows the user to select an item from a list.
 
+    The popup's position will depend on the passed parameters.
+    If position is passed then the popup's top left corner will be that point.
+    Otherwise, the popup will use get_popup_position to be centered on the top third of the parent_rect if it is passed or the window if parent_rect is None.
+    The position_offset is CSS standard, meaning positive values are down, right
+    Passing position_offset as IntSize will be treated as a pixel offset from the top left position.
+    Passing position_offset a FloatSize will be treated as a percentage of the popup size to offset from the top left position.
+    """
     item_getter = item_getter or str
 
     class Handler:
@@ -287,6 +297,8 @@ def pose_select_item_pop_up(items: typing.Sequence[typing.Any], completion_fn: t
     # calculate the max string width, add 10%, min 200, max 480
     width = min(max(int(max([window.get_font_metrics("system", item_getter(c)).width for c in items]) * 1.10), 200), 480)
 
+    size, position = _get_pop_up_size_and_position(window, position=position, size=size, parent_rect=parent_rect, position_offset=position_offset)
+
     ui_handler = Handler()
     u = Declarative.DeclarativeUI()
     title_row = u.create_row(u.create_label(text=title or _("Select Item")), u.create_stretch())
@@ -305,13 +317,23 @@ def pose_select_item_pop_up(items: typing.Sequence[typing.Any], completion_fn: t
             old_close()
 
     popup.on_close = functools.partial(handle_close, popup.on_close)
-    popup.show()#position=position, size=size)
+    popup.show(position=position, size=size)
 
 
 def pose_edit_string_pop_up(current_string: str, completion_fn: typing.Callable[[str | None], None], *,
                             window: Window.Window, title: typing.Optional[str] = None,
-                            position: Geometry.IntPoint | None = None, size: Geometry.IntSize | None = None) -> None:
+                            position: Geometry.IntPoint | None = None, size: Geometry.IntSize | None = None,
+                            parent_rect: Geometry.IntRect | None = None, position_offset: Geometry.IntSize | Geometry.FloatSize | None = None) -> None:
+    """ Create a popup with a text input field.
 
+    Setting cancel_button_text or accept_button_text will display buttons below the input field.
+    The popup's position will depend on the passed parameters.
+    If position is passed then the popup's top left corner will be that point.
+    Otherwise, the popup will use get_popup_position to be centered on the top third of the parent_rect if it is passed or the window if parent_rect is None.
+    The position_offset is CSS standard, meaning positive values are down, right
+    Passing position_offset as IntSize will be treated as a pixel offset from the top left position.
+    Passing position_offset a FloatSize will be treated as a percentage of the popup size to offset from the top left position.
+    """
     class Handler:
         def __init__(self, s: str) -> None:
             self.is_rejected = True
@@ -350,7 +372,7 @@ def pose_edit_string_pop_up(current_string: str, completion_fn: typing.Callable[
             self.__request_close_fn()
 
     from nion.ui import Declarative  # avoid circular reference
-
+    size, position = _get_pop_up_size_and_position(window, position=position, size=size, parent_rect=parent_rect, position_offset=position_offset)
     # calculate the max string width, add 10%, min 200, max 480
     size = size or Geometry.IntSize(30, 200)
     width = (size.width - 20) if size else min(max(int(window.get_font_metrics("system", current_string).width * 1.10), 200), 480)
@@ -380,3 +402,45 @@ def pose_edit_string_pop_up(current_string: str, completion_fn: typing.Callable[
     assert line_edit_widget
     line_edit_widget.focused = False
     line_edit_widget.focused = True
+
+
+def _get_popup_position_from_parent_rect(parent_panel_rect: Geometry.IntRect, popup_size: Geometry.IntSize) -> Geometry.IntPoint:
+    """ Calculate the position for a popup panel from the parent container, and its size.
+
+    It is vertically aligned to be hanging from the top third of the parent panel.
+    """
+    vertical_position = parent_panel_rect.top + parent_panel_rect.height // 2 // 3
+    return Geometry.IntPoint(x=parent_panel_rect.left + (parent_panel_rect.width - popup_size.width) // 2, y=vertical_position + popup_size.height)
+
+
+def _get_pop_up_size_and_position(window: Window.Window, position: Geometry.IntPoint | None = None,
+                                  size: Geometry.IntSize | None = None, parent_rect: Geometry.IntRect | None = None,
+                                  position_offset: Geometry.IntSize | Geometry.FloatSize | None = None)\
+        -> tuple[Geometry.IntSize, Geometry.IntPoint]:
+    """ Calculate the size and position of a popup.
+
+    The popup's position will depend on the passed parameters.
+    If position is passed then the popup's top left corner will be that point.
+    Otherwise, the popup will use get_popup_position to be centered on the top third of the parent_rect if it is passed or the window if parent_rect is None.
+    The position_offset is CSS standard, meaning positive values are down, right
+    Passing position_offset as IntSize will be treated as a pixel offset from the top left position.
+    Passing position_offset a FloatSize will be treated as a percentage of the popup size to offset from the top left position.
+    """
+    size = size or Geometry.IntSize(width=400, height=100)
+    assert size is not None
+
+    if position is None:
+        if parent_rect is None:
+            parent_size = window._document_window.size or window._document_window.screen_size
+            parent_position = window._document_window.position
+            parent_rect = Geometry.IntRect(origin=parent_position, size=parent_size)
+        assert parent_rect is not None
+        position = _get_popup_position_from_parent_rect(parent_rect, size)
+
+    if position_offset is not None:  # Offset is CSS standard, meaning positive values are down, right
+        if isinstance(position_offset, Geometry.IntSize):
+            position = Geometry.IntPoint(position.y + position_offset.height, position.x + position_offset.width)
+        elif isinstance(position_offset, Geometry.FloatSize):
+            position = Geometry.IntPoint(position.y + int(size.height * position_offset.height), position.x + int(size.width * position_offset.width))
+
+    return size, position

--- a/nion/ui/Dialog.py
+++ b/nion/ui/Dialog.py
@@ -310,15 +310,17 @@ def pose_select_item_pop_up(items: typing.Sequence[typing.Any], completion_fn: t
 
 def pose_edit_string_pop_up(current_string: str, completion_fn: typing.Callable[[str | None], None], *,
                             window: Window.Window, title: typing.Optional[str] = None,
-                            position: Geometry.IntPoint | None = None, size: Geometry.IntSize | None = None, window_style: str | None = None,
+                            position: Geometry.IntPoint | None = None, size: Geometry.IntSize | None = None,
                             cancel_button_text: str | None = None, accept_button_text: str | None = None) -> None:
+    """Create a popup with a text input field.
 
+    Setting cancel_button_text or accept_button_text will display buttons below the input field.
+    """
     class Handler:
         def __init__(self, s: str) -> None:
             self.is_rejected = True
             self.s = s
             self.line_edit_widget: UserInterface.LineEditWidget | None = None
-            self.call_close_on_reject = window_style != "default"
 
         def close(self) -> None:
             pass
@@ -336,8 +338,6 @@ def pose_edit_string_pop_up(current_string: str, completion_fn: typing.Callable[
 
         def reject(self, widget: UserInterface.Widget) -> bool:
             # receive this when the user hits escape. let the window handle the escape by returning False.
-            if self.call_close_on_reject:
-                self.__request_close_fn()
             return False
 
         def accept(self, widget: UserInterface.Widget) -> bool:
@@ -352,9 +352,8 @@ def pose_edit_string_pop_up(current_string: str, completion_fn: typing.Callable[
             self.__request_close_fn()
 
     from nion.ui import Declarative  # avoid circular reference
-
-    # calculate the max string width, add 10%, min 200, max 480
     size = size or Geometry.IntSize(30, 200)
+    # calculate the max string width, add 10%, min 200, max 480
     width = (size.width - 20) if size else min(max(int(window.get_font_metrics("system", current_string).width * 1.10), 200), 480)
 
     ui_handler = Handler(current_string)
@@ -371,8 +370,8 @@ def pose_edit_string_pop_up(current_string: str, completion_fn: typing.Callable[
                                   u.create_push_button(text=cancel_button_text, on_clicked="handle_cancel"),
                                   u.create_push_button(text=accept_button_text, on_clicked="accept"), spacing=8, margin=8)
         column = u.create_column(u.create_column(column, u.create_stretch()), button_row)
-    # passing window_style='popup' previously did not handle copy/paste, this issue seems to be resolved.
-    popup = PopupWindow(window, column, ui_handler, window_style=window_style, delegate=ui_handler)
+    # Passing window_style='popup' previously did not handle copy/paste, this issue seems to be resolved.
+    popup = PopupWindow(window, column, ui_handler, window_style='popup', delegate=ui_handler)
 
     def handle_close(old_close: typing.Callable[[], None] | None) -> None:
         if not ui_handler.is_rejected:

--- a/nion/ui/Dialog.py
+++ b/nion/ui/Dialog.py
@@ -407,6 +407,89 @@ def pose_edit_string_pop_up(current_string: str, completion_fn: typing.Callable[
     line_edit_widget.focused = True
 
 
+def pose_confirmation_pop_up(completion_fn: typing.Callable[[bool], None], *,
+                             window: Window.Window, title: str | None = None, caption: str | None = None,
+                             position: Geometry.IntPoint | None = None, size: Geometry.IntSize | None = None,
+                             cancel_button_text: str | None = None, accept_button_text: str | None = None,
+                             parent_rect: Geometry.IntRect | None = None,
+                             position_offset: Geometry.IntSize | Geometry.FloatSize | None = None) -> None:
+    """ Display a confirmation popup.
+
+    The popup's position will depend on the passed parameters.
+    If position is passed then the popup's top left corner will be that point.
+    Otherwise, the popup will use get_popup_position to be centered on the top third of the parent_rect if it is passed or the window if parent_rect is None.
+    The position_offset is CSS standard, meaning positive values are down, right
+    Passing position_offset as IntSize will be treated as a pixel offset from the top left position.
+    Passing position_offset a FloatSize will be treated as a percentage of the popup size to offset from the top left position.
+    """
+    class Handler:
+        def __init__(self) -> None:
+            self.is_rejected = True
+
+        def close(self) -> None:
+            pass
+
+        def init_popup(self, request_close_fn: typing.Callable[[], None]) -> None:
+            self.__request_close_fn = request_close_fn
+
+        def reject(self, widget: UserInterface.Widget) -> bool:
+            # receive this when the user hits escape. let the window handle the escape by returning False.
+            # mark popup as rejected.
+            return False
+
+        def accept(self, widget: UserInterface.Widget) -> bool:
+            # receive this when the user hits return. need to request a close and return True to say we handled event.
+            self.is_rejected = False
+            self.__request_close_fn()
+            return True
+
+        def handle_cancel(self, widget: UserInterface.Widget) -> None:
+            self.__request_close_fn()
+
+    from nion.ui import Declarative  # avoid circular reference
+
+    # calculate the max string width, add 10%, min 200, max 480
+    size, position = _get_pop_up_size_and_position(window, position=position, size=size, parent_rect=parent_rect, position_offset=position_offset)
+
+    ui_handler = Handler()
+    u = Declarative.DeclarativeUI()
+
+    title_row = u.create_row(u.create_label(text=title or _("Confirm")), margin_left=8, margin_right=8, margin_top=4, margin_bottom=4, background_color="#DDD")
+    button_row = None
+    if cancel_button_text is not None or accept_button_text is not None:
+        cancel_button_text = cancel_button_text or _("Cancel")
+        accept_button_text = accept_button_text or _("Done")
+        button_row = u.create_row(u.create_stretch(),
+                                  u.create_push_button(text=cancel_button_text, on_clicked="handle_cancel"),
+                                  u.create_push_button(text=accept_button_text, on_clicked="accept"), spacing=8, margin=8)
+
+    caption_row = None
+    if caption:
+        caption_row = u.create_row(u.create_label(text=caption), u.create_stretch(), spacing=4, margin=8)
+
+    if button_row is not None and caption_row is not None:
+        column = u.create_column(title_row, caption_row, button_row)
+    elif button_row is not None:
+        column = u.create_column(title_row, button_row)
+    elif caption_row is not None:
+        column = u.create_column(title_row, caption_row)
+    else:
+        column = u.create_column(title_row)
+
+    popup = PopupWindow(window, column, ui_handler, window_style="popup", delegate=ui_handler)
+
+    def handle_close(old_close: typing.Callable[[], None] | None) -> None:
+        if not ui_handler.is_rejected:
+            completion_fn(True)
+        else:
+            completion_fn(False)
+        if callable(old_close):
+            old_close()
+
+    popup.on_close = functools.partial(handle_close, popup.on_close)
+    popup.show(size=size, position=position)
+
+
 def _get_popup_position_from_parent_rect(parent_panel_rect: Geometry.IntRect, popup_size: Geometry.IntSize) -> Geometry.IntPoint:
     """ Calculate the position for a popup panel from the parent container, and its size.
 

--- a/nion/ui/Dialog.py
+++ b/nion/ui/Dialog.py
@@ -344,8 +344,8 @@ def pose_edit_string_pop_up(current_string: str, completion_fn: typing.Callable[
             # receive this when the user hits return. need to request a close and return True to say we handled event.
             if self.line_edit_widget:
                 self.s = self.line_edit_widget.text or str()
-            self.__request_close_fn()
             self.is_rejected = False
+            self.__request_close_fn()
             return True
 
         def handle_cancel(self, widget: UserInterface.Widget) -> None:
@@ -392,8 +392,8 @@ def pose_edit_string_pop_up(current_string: str, completion_fn: typing.Callable[
 
 def pose_confirmation_pop_up(completion_fn: typing.Callable[[bool], None], *,
                              window: Window.Window, title: str | None = None, caption: str | None = None,
-                             position: Geometry.IntPoint | None = None, size: Geometry.IntSize | None = None, window_style: str | None = None,
-                             cancel_button_text: str = _("Cancel"), accept_button_text: str = _("Done")) -> None:
+                             position: Geometry.IntPoint | None = None, size: Geometry.IntSize | None = None,
+                             cancel_button_text: str | None = None, accept_button_text: str | None = None) -> None:
     """Display a confirmation popup"""
     class Handler:
         def __init__(self) -> None:
@@ -408,14 +408,16 @@ def pose_confirmation_pop_up(completion_fn: typing.Callable[[bool], None], *,
         def reject(self, widget: UserInterface.Widget) -> bool:
             # receive this when the user hits escape. let the window handle the escape by returning False.
             # mark popup as rejected.
-            self.__request_close_fn()
             return False
 
         def accept(self, widget: UserInterface.Widget) -> bool:
             # receive this when the user hits return. need to request a close and return True to say we handled event.
-            self.__request_close_fn()
             self.is_rejected = False
+            self.__request_close_fn()
             return True
+
+        def handle_cancel(self, widget: UserInterface.Widget) -> None:
+            self.__request_close_fn()
 
     from nion.ui import Declarative  # avoid circular reference
 
@@ -428,17 +430,28 @@ def pose_confirmation_pop_up(completion_fn: typing.Callable[[bool], None], *,
     title_row = u.create_row(u.create_label(text=title or _("Confirm")), margin_left=8, margin_right=8, margin_top=4, margin_bottom=4, background_color="#DDD")
     divider = u.create_row(u.create_stretch(), background_color="#AAA", height=1)
     title_row = u.create_column(title_row, divider)
-    button_row = u.create_row(u.create_stretch(),
-                              u.create_push_button(text=cancel_button_text, on_clicked="reject"),
-                              u.create_push_button(text=accept_button_text, on_clicked="accept"), spacing=8, margin=8)
+    button_row = None
+    if cancel_button_text is not None or accept_button_text is not None:
+        cancel_button_text = cancel_button_text or _("Cancel")
+        accept_button_text = accept_button_text or _("Done")
+        button_row = u.create_row(u.create_stretch(),
+                                  u.create_push_button(text=cancel_button_text, on_clicked="handle_cancel"),
+                                  u.create_push_button(text=accept_button_text, on_clicked="accept"), spacing=8, margin=8)
 
+    caption_row = None
     if caption:
         caption_row = u.create_row(u.create_label(text=caption), u.create_stretch(), spacing=4, margin=8)
-        column = u.create_column(title_row, caption_row, button_row)
-    else:
-        column = u.create_column(title_row, button_row)
 
-    popup = PopupWindow(window, column, ui_handler, window_style=window_style, delegate=ui_handler)
+    if button_row is not None and caption_row is not None:
+        column = u.create_column(title_row, caption_row, button_row)
+    elif button_row is not None:
+        column = u.create_column(title_row, button_row)
+    elif caption_row is not None:
+        column = u.create_column(title_row, caption_row)
+    else:
+        column = u.create_column(title_row)
+
+    popup = PopupWindow(window, column, ui_handler, window_style="popup", delegate=ui_handler)
 
     def handle_close(old_close: typing.Callable[[], None] | None) -> None:
         if not ui_handler.is_rejected:

--- a/nion/ui/Dialog.py
+++ b/nion/ui/Dialog.py
@@ -11,6 +11,8 @@ import time
 import typing
 import weakref
 
+from fontTools.subset import prune_hints
+
 # third party libraries
 # none
 
@@ -243,8 +245,8 @@ class PopupWindow(Window.Window):
 
 def pose_select_item_pop_up(items: typing.Sequence[typing.Any], completion_fn: typing.Callable[[typing.Any], None], *,
                             window: Window.Window, current_item: int = 0,
-                            item_getter: typing.Optional[typing.Callable[[typing.Any], str]] = None,
-                            title: typing.Optional[str] = None, position: Geometry.IntPoint | None = None,
+                            item_getter: typing.Callable[[typing.Any], str] | None = None,
+                            title: str | None = None, position: Geometry.IntPoint | None = None,
                             size: Geometry.IntSize | None = None, parent_rect: Geometry.IntRect | None = None,
                             position_offset: Geometry.IntSize | Geometry.FloatSize | None = None) -> None:
     """Create a popup that allows the user to select an item from a list.
@@ -321,13 +323,12 @@ def pose_select_item_pop_up(items: typing.Sequence[typing.Any], completion_fn: t
 
 
 def pose_edit_string_pop_up(current_string: str, completion_fn: typing.Callable[[str | None], None], *,
-                            window: Window.Window, title: typing.Optional[str] = None,
+                            window: Window.Window, title: str | None = None,
                             position: Geometry.IntPoint | None = None, size: Geometry.IntSize | None = None,
-                            cancel_button_text: str | None = None, accept_button_text: str | None = None,
+                            cancel_button_text: str | None = None, accept_button_text: str | None = None, show_buttons: bool = False,
                             parent_rect: Geometry.IntRect | None = None, position_offset: Geometry.IntSize | Geometry.FloatSize | None = None) -> None:
     """ Create a popup with a text input field.
 
-    Setting cancel_button_text or accept_button_text will display buttons below the input field.
     The popup's position will depend on the passed parameters.
     If position is passed then the popup's top left corner will be that point.
     Otherwise, the popup will use get_popup_position to be centered on the top third of the parent_rect if it is passed or the window if parent_rect is None.
@@ -356,7 +357,8 @@ def pose_edit_string_pop_up(current_string: str, completion_fn: typing.Callable[
             self.accept(widget)
 
         def reject(self, widget: UserInterface.Widget) -> bool:
-            # receive this when the user hits escape. let the window handle the escape by returning False.
+            # Receive this when the user hits escape. Let the window handle the escape by returning False.
+            # The window will close when reject is called on a popup, so calling self.__request_close_fn() is not necessary here.
             return False
 
         def accept(self, widget: UserInterface.Widget) -> bool:
@@ -380,7 +382,7 @@ def pose_edit_string_pop_up(current_string: str, completion_fn: typing.Callable[
     title_row = u.create_row(u.create_label(text=title or _("Edit")), margin_left=8, margin_right=8, margin_top=4, margin_bottom=4, background_color="#DDD")
     edit_row = u.create_row(u.create_line_edit(name="line_edit_widget", text="@binding(s)", on_return_pressed="accept", on_escape_pressed="reject", width=width), u.create_stretch(), spacing=4, margin=8)
     column = u.create_column(title_row, edit_row, u.create_stretch())
-    if cancel_button_text is not None or accept_button_text is not None:
+    if show_buttons:
         cancel_button_text = cancel_button_text or _("Cancel")
         accept_button_text = accept_button_text or _("Done")
         button_row = u.create_row(u.create_stretch(),
@@ -411,7 +413,7 @@ def pose_confirmation_pop_up(completion_fn: typing.Callable[[bool], None], *,
                              window: Window.Window, title: str | None = None, caption: str | None = None,
                              position: Geometry.IntPoint | None = None, size: Geometry.IntSize | None = None,
                              cancel_button_text: str | None = None, accept_button_text: str | None = None,
-                             parent_rect: Geometry.IntRect | None = None,
+                             show_buttons: bool = False, parent_rect: Geometry.IntRect | None = None,
                              position_offset: Geometry.IntSize | Geometry.FloatSize | None = None) -> None:
     """ Display a confirmation popup.
 
@@ -433,8 +435,8 @@ def pose_confirmation_pop_up(completion_fn: typing.Callable[[bool], None], *,
             self.__request_close_fn = request_close_fn
 
         def reject(self, widget: UserInterface.Widget) -> bool:
-            # receive this when the user hits escape. let the window handle the escape by returning False.
-            # mark popup as rejected.
+            # Receive this when the user hits escape. Let the window handle the escape by returning False.
+            # The window will close when reject is called on a popup, so calling self.__request_close_fn() is not necessary here.
             return False
 
         def accept(self, widget: UserInterface.Widget) -> bool:
@@ -456,7 +458,7 @@ def pose_confirmation_pop_up(completion_fn: typing.Callable[[bool], None], *,
 
     title_row = u.create_row(u.create_label(text=title or _("Confirm")), margin_left=8, margin_right=8, margin_top=4, margin_bottom=4, background_color="#DDD")
     button_row = None
-    if cancel_button_text is not None or accept_button_text is not None:
+    if show_buttons:
         cancel_button_text = cancel_button_text or _("Cancel")
         accept_button_text = accept_button_text or _("Done")
         button_row = u.create_row(u.create_stretch(),
@@ -493,10 +495,10 @@ def pose_confirmation_pop_up(completion_fn: typing.Callable[[bool], None], *,
 def _get_popup_position_from_parent_rect(parent_panel_rect: Geometry.IntRect, popup_size: Geometry.IntSize) -> Geometry.IntPoint:
     """ Calculate the position for a popup panel from the parent container, and its size.
 
-    It is vertically aligned to be hanging from the top third of the parent panel.
+    It is vertically aligned to the top third of the parent panel.
     """
-    vertical_position = parent_panel_rect.top + parent_panel_rect.height // 2 // 3
-    return Geometry.IntPoint(x=parent_panel_rect.left + (parent_panel_rect.width - popup_size.width) // 2, y=vertical_position + popup_size.height)
+    vertical_position = parent_panel_rect.top + parent_panel_rect.height // 3
+    return Geometry.IntPoint(x=parent_panel_rect.left + (parent_panel_rect.width - popup_size.width) // 2, y=vertical_position)
 
 
 def _get_pop_up_size_and_position(window: Window.Window, position: Geometry.IntPoint | None = None,

--- a/nion/ui/Dialog.py
+++ b/nion/ui/Dialog.py
@@ -414,9 +414,10 @@ def pose_confirmation_pop_up(completion_fn: typing.Callable[[bool], None], *,
                              position: Geometry.IntPoint | None = None, size: Geometry.IntSize | None = None,
                              cancel_button_text: str | None = None, accept_button_text: str | None = None,
                              show_buttons: bool = False, parent_rect: Geometry.IntRect | None = None,
-                             position_offset: Geometry.IntSize | Geometry.FloatSize | None = None) -> None:
+                             position_offset: Geometry.IntSize | Geometry.FloatSize | None = None, show_cancel_button: bool = True) -> None:
     """ Display a confirmation popup.
 
+    show_cancel_button parameter is for when show_buttons is True, but you only want to show the accept button.
     The popup's position will depend on the passed parameters.
     If position is passed then the popup's top left corner will be that point.
     Otherwise, the popup will use get_popup_position to be centered on the top third of the parent_rect if it is passed or the window if parent_rect is None.
@@ -461,9 +462,13 @@ def pose_confirmation_pop_up(completion_fn: typing.Callable[[bool], None], *,
     if show_buttons:
         cancel_button_text = cancel_button_text or _("Cancel")
         accept_button_text = accept_button_text or _("Done")
-        button_row = u.create_row(u.create_stretch(),
-                                  u.create_push_button(text=cancel_button_text, on_clicked="handle_cancel"),
-                                  u.create_push_button(text=accept_button_text, on_clicked="accept"), spacing=8, margin=8)
+        if show_cancel_button:
+            button_row = u.create_row(u.create_stretch(),
+                                      u.create_push_button(text=cancel_button_text, on_clicked="handle_cancel"),
+                                      u.create_push_button(text=accept_button_text, on_clicked="accept"), spacing=8, margin=8)
+        else:
+            button_row = u.create_row(u.create_stretch(),
+                                     u.create_push_button(text=accept_button_text, on_clicked="accept"), spacing=8, margin=8)
 
     caption_row = None
     if caption:

--- a/nion/ui/Dialog.py
+++ b/nion/ui/Dialog.py
@@ -352,7 +352,7 @@ def pose_edit_string_pop_up(current_string: str, completion_fn: typing.Callable[
             self.__request_close_fn()
 
     from nion.ui import Declarative  # avoid circular reference
-    size = size or Geometry.IntSize(30, 200)
+    size = size or Geometry.IntSize(width=400, height=100)
     # calculate the max string width, add 10%, min 200, max 480
     width = (size.width - 20) if size else min(max(int(window.get_font_metrics("system", current_string).width * 1.10), 200), 480)
 
@@ -422,7 +422,7 @@ def pose_confirmation_pop_up(completion_fn: typing.Callable[[bool], None], *,
     from nion.ui import Declarative  # avoid circular reference
 
     # calculate the max string width, add 10%, min 200, max 480
-    size = size or Geometry.IntSize(30, 200)
+    size = size or Geometry.IntSize(width=400, height=100)
 
     ui_handler = Handler()
     u = Declarative.DeclarativeUI()


### PR DESCRIPTION
Fixes #132. Adds arguments for the window style and Cancel and Done buttons.
Remove unnecessary call to __request_close_fn in reject that caused a console error when clicking escape.
If either button is a string then it will display the buttons, otherwise it will have the existing behavior of not having buttons.